### PR TITLE
fix nikaia region

### DIFF
--- a/weather.xml
+++ b/weather.xml
@@ -12291,7 +12291,7 @@
       <zoom2>3</zoom2>
     </city>
     <city jpn="Nikea" eng="Nikaia" de="Nikea" fr="Nikea" es="Nikea" it="Nikea" nl="Nikea">
-      <province jpn="テッサリーア" eng="Thessaly" de="Thessalien" fr="Thessalie" es="Tesalia" it="Tessaglia" nl="Thessalië" />
+      <province jpn="アッティカ" eng="Attica" de="Attika" fr="Attique" es="Ática" it="Attica" nl="Attika" />
       <longitude>23.609619140625</longitude>
       <latitude>37.9193115234375</latitude>
       <zoom1>0</zoom1>


### PR DESCRIPTION
Author Name for Credits: Eridion

Short Description: Fixed Nikaia region on Forecast channel

Long Description: DESCRIPTION I found an interesting bug on forecast channel with on select the region says that Nikaia is in Thessaly but this Nikaia referred on forecast list refers to Attica one i can confirm it with Forecast channel globe and this PR fixes it

https://user-images.githubusercontent.com/14198423/219123663-38d5375f-e635-4e33-bfc9-86efdf4d44c7.mp4

