### PR TITLE
Fixed České Budějovice coordinates

### DIFF
--- a/weather.xml
+++ b/weather.xml
@@ -23642,8 +23642,8 @@
     </city>
     <city jpn="チェスケー・ブジェヨヴィツェ" eng="Ceske Budejovice" de="Budweis" fr="Ceske Budejovice" es="Ceske Budejovice" it="Ceske Budejovice" nl="Ceske Budejovice">
       <province jpn="南ボヘミア州" eng="South Bohemia" de="Südböhmische Region" fr="Bohême-du-Sud" es="Bohemia Meridional" it="Boemia Meridionale" nl="Zuid-Bohemen" />
-      <longitude>14.015481</longitude>
-      <latitude>50.730035</latitude>
+      <longitude>14.474722</longitude>
+      <latitude>48.974722</latitude>
       <zoom1>1</zoom1>
       <zoom2>3</zoom2>
     </city>


### PR DESCRIPTION
Fixed the coordinates of České Budějovice
They were incorrectly at north of Czech Republic instead of at the south