### PR TITLE
Fix for Nuevo León, Yucatán & Veracruz States from Mexico

### DIFF
--- a/weather.xml
+++ b/weather.xml
@@ -5836,49 +5836,49 @@
       <zoom2>3</zoom2>
     </city>
     <city jpn="ハラパ" eng="Xalapa" de="Xalapa" fr="Xalapa" es="Xalapa Enríquez" it="Xalapa" nl="Xalapa">
-      <province jpn="ベラクルス州" eng="Veracruz-Llave" de="Veracruz" fr="Veracruz" es="Veracruz-Llave" it="Veracruz" nl="Veracruz" />
+      <province jpn="ベラクルス州" eng="Veracruz" de="Veracruz" fr="Veracruz" es="Veracruz" it="Veracruz" nl="Veracruz" />
       <longitude>-96.9158935546875</longitude>
       <latitude>19.5281982421875</latitude>
       <zoom1>3</zoom1>
       <zoom2>3</zoom2>
     </city>
     <city jpn="コアツァコアルコス" eng="Coatzacoalcos" de="Coatzacoalcos" fr="Coatzacoalcos" es="Coatzacoalcos" it="Coatzacoalcos" nl="Coatzacoalcos">
-      <province jpn="ベラクルス州" eng="Veracruz-Llave" de="Veracruz" fr="Veracruz" es="Veracruz-Llave" it="Veracruz" nl="Veracruz" />
+      <province jpn="ベラクルス州" eng="Veracruz" de="Veracruz" fr="Veracruz" es="Veracruz" it="Veracruz" nl="Veracruz" />
       <longitude>-94.41650390625</longitude>
       <latitude>18.1494140625</latitude>
       <zoom1>3</zoom1>
       <zoom2>3</zoom2>
     </city>
     <city jpn="オリサバ" eng="Orizaba" de="Orizaba" fr="Orizaba" es="Orizaba" it="Orizaba" nl="Orizaba">
-      <province jpn="ベラクルス州" eng="Veracruz-Llave" de="Veracruz" fr="Veracruz" es="Veracruz-Llave" it="Veracruz" nl="Veracruz" />
+      <province jpn="ベラクルス州" eng="Veracruz" de="Veracruz" fr="Veracruz" es="Veracruz" it="Veracruz" nl="Veracruz" />
       <longitude>-97.09716796875</longitude>
       <latitude>18.8470458984375</latitude>
       <zoom1>1</zoom1>
       <zoom2>3</zoom2>
     </city>
     <city jpn="ポサ・リカ" eng="Poza Rica de Hidalgo" de="Poza Rica de Hidalgo" fr="Poza Rica" es="Poza Rica" it="Poza Rica" nl="Poza Rica">
-      <province jpn="ベラクルス州" eng="Veracruz-Llave" de="Veracruz" fr="Veracruz" es="Veracruz-Llave" it="Veracruz" nl="Veracruz" />
+      <province jpn="ベラクルス州" eng="Veracruz" de="Veracruz" fr="Veracruz" es="Veracruz" it="Veracruz" nl="Veracruz" />
       <longitude>-97.44873046875</longitude>
       <latitude>20.5499267578125</latitude>
       <zoom1>5</zoom1>
       <zoom2>3</zoom2>
     </city>
     <city jpn="ベラクルス" eng="Veracruz" de="Veracruz" fr="Veracruz" es="Veracruz" it="Veracruz" nl="Veracruz">
-      <province jpn="ベラクルス州" eng="Veracruz-Llave" de="Veracruz" fr="Veracruz" es="Veracruz-Llave" it="Veracruz" nl="Veracruz" />
+      <province jpn="ベラクルス州" eng="Veracruz" de="Veracruz" fr="Veracruz" es="Veracruz" it="Veracruz" nl="Veracruz" />
       <longitude>-96.13037109375</longitude>
       <latitude>19.1986083984375</latitude>
       <zoom1>5</zoom1>
       <zoom2>3</zoom2>
     </city>
     <city jpn="メリダ" eng="Merida" de="Mérida" fr="Mérida" es="Mérida" it="Mérida" nl="Mérida">
-      <province jpn="ベラクルス州" eng="Veracruz-Llave" de="Veracruz" fr="Veracruz" es="Veracruz-Llave" it="Veracruz" nl="Veracruz" />
+      <province jpn="ユカタン" eng="Yucatán" de="" fr="Yucatán" es="Yucatán" it="Yucatán" nl="Yucatán" />
       <longitude>-89.615478515625</longitude>
       <latitude>20.9619140625</latitude>
       <zoom1>5</zoom1>
       <zoom2>3</zoom2>
     </city>
     <city jpn="プログレソ" eng="Progreso" de="Progreso" fr="Progreso" es="Progreso" it="Progreso" nl="Progreso">
-      <province jpn="ベラクルス州" eng="Veracruz-Llave" de="Veracruz" fr="Veracruz" es="Veracruz-Llave" it="Veracruz" nl="Veracruz" />
+      <province jpn="ユカタン" eng="Yucatán" de="" fr="Yucatán" es="Yucatán" it="Yucatán" nl="Yucatán" />
       <longitude>-89.6649169921875</longitude>
       <latitude>21.280517578125</latitude>
       <zoom1>0</zoom1>


### PR DESCRIPTION
An adjustment is made for the following cities of Mexico:

- “Monterrey” is assigned to the state of Nuevo León, Nayarit is removed as it was incorrect.

- “Veracruz Llave” is updated to “Veracruz” only, as the former is incorrect.

- The cities of Mérida & Progreso are assigned to the state of Yucatán, Veracruz is removed as it was incorrect.

Official sources: 

https://www.gob.mx/ime/acciones-y-programas/estado-de-la-republica-mexicana

