### PR TITLE
Add Baden, Switzerland forecast location

### DIFF
--- a/weather.xml
+++ b/weather.xml
@@ -21329,6 +21329,13 @@
       <zoom1>1</zoom1>
       <zoom2>3</zoom2>
     </city>
+    <city jpn="バーデン" eng="Baden" de="Baden" fr="Baden" es="Baden" it="Baden" nl="Baden">
+      <province jpn="アールガウ州" eng="Aargau" de="Aargau" fr="Argovie" es="Argovia" it="Argovia" nl="Aargau" />
+      <longitude>8.30592155456543</longitude>
+      <latitude>47.47333005480522</latitude>
+      <zoom1>1</zoom1>
+      <zoom2>3</zoom2>
+    </city>
     <city jpn="バーゼル" eng="Basle" de="Basel" fr="Bâle" es="Basilea" it="Basilea" nl="Bazel">
       <province jpn="バーゼル" eng="Basle-City" de="Basel-Stadt" fr="Bâle-Ville" es="Basilea-Ciudad" it="Basilea Città" nl="Bazel-Stad" />
       <longitude>7.5860595703125</longitude>


### PR DESCRIPTION
## Summary

- add Baden, Aargau to Switzerland's national Forecast Channel location list
- include the existing seven PAL-language name and canton fields
- use the same national-location visibility settings as nearby Aarau

## Why

Baden is not currently present in the Switzerland list, while Aarau is the only existing Aargau location. Adding Baden gives users in and around the Baden district a closer selectable forecast point with the national forecast features.

Coordinates: [GeoNames — Baden, Aargau](https://www.geonames.org/2661646/baden.html) (47.47333005480522, 8.30592155456543).

## Validation

- parsed `weather.xml` successfully
- confirmed exactly one Baden entry
- confirmed no duplicate Swiss city names
- confirmed latitude/longitude ranges
- `git diff --check` passes
- local Go build was not run because the Go toolchain was unavailable; repository CI can perform the full generator checks

## AI assistance

This small XML contribution was prepared with AI assistance and reviewed against the existing Switzerland schema and GeoNames coordinates.
